### PR TITLE
2729 old plugin build fails due to engine configuration Id.

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cxplugin</artifactId>
     <groupId>com.checkmarx.teamcity</groupId>
-    <version>2021.2.3</version>
+    <version>2021.3.1</version>
   </parent>
   <artifactId>build</artifactId>
   <packaging>pom</packaging>

--- a/cxplugin-agent/pom.xml
+++ b/cxplugin-agent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cxplugin</artifactId>
         <groupId>com.checkmarx.teamcity</groupId>
-        <version>2021.2.3</version>
+        <version>2021.3.1</version>
     </parent>
     <artifactId>cxplugin-agent</artifactId>
     <packaging>jar</packaging>

--- a/cxplugin-agent/src/main/java/com/checkmarx/teamcity/agent/CxConfigHelper.java
+++ b/cxplugin-agent/src/main/java/com/checkmarx/teamcity/agent/CxConfigHelper.java
@@ -96,9 +96,7 @@ public class CxConfigHelper {
             then Project will get scanned as per SAST set configuration Id.
             */
             Integer engConfigId = convertToIntegerIfNotNull(buildParameters.get(ENGINE_CONFIG_ID), ENGINE_CONFIG_ID);
-            if (engConfigId == null) {
-                throw new InvalidParameterException("Invalid Engine Configuration Id.");
-            }
+
             ret.setEngineConfigurationId(engConfigId);
 
             ret.setGeneratePDFReport(TRUE.equals(buildParameters.get(GENERATE_PDF_REPORT)));

--- a/cxplugin-common/pom.xml
+++ b/cxplugin-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cxplugin</artifactId>
     <groupId>com.checkmarx.teamcity</groupId>
-    <version>2021.2.3</version>
+    <version>2021.3.1</version>
   </parent>
   <artifactId>cxplugin-common</artifactId>
   <packaging>jar</packaging>

--- a/cxplugin-server/pom.xml
+++ b/cxplugin-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cxplugin</artifactId>
         <groupId>com.checkmarx.teamcity</groupId>
-        <version>2021.2.3</version>
+        <version>2021.3.1</version>
     </parent>
     <artifactId>cxplugin-server</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.checkmarx.teamcity</groupId>
     <artifactId>cxplugin</artifactId>
-    <version>2021.2.3</version>
+    <version>2021.3.1</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
If we don't specify value for engine configuration Id.. i.e. for mentioned case then by default it will use 1 as engine configuration Id.