### PR TITLE
Log4j fix

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cxplugin</artifactId>
     <groupId>com.checkmarx.teamcity</groupId>
-    <version>2021.3.1</version>
+    <version>2021.4.1</version>
   </parent>
   <artifactId>build</artifactId>
   <packaging>pom</packaging>

--- a/cxplugin-agent/pom.xml
+++ b/cxplugin-agent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cxplugin</artifactId>
         <groupId>com.checkmarx.teamcity</groupId>
-        <version>2021.3.1</version>
+        <version>2021.4.1</version>
     </parent>
     <artifactId>cxplugin-agent</artifactId>
     <packaging>jar</packaging>

--- a/cxplugin-common/pom.xml
+++ b/cxplugin-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cxplugin</artifactId>
     <groupId>com.checkmarx.teamcity</groupId>
-    <version>2021.3.1</version>
+    <version>2021.4.1</version>
   </parent>
   <artifactId>cxplugin-common</artifactId>
   <packaging>jar</packaging>

--- a/cxplugin-common/pom.xml
+++ b/cxplugin-common/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.checkmarx</groupId>
       <artifactId>cx-client-common</artifactId>
-      <version>2021.2.162</version>
+      <version>2021.4.9</version>
       <exclusions>
         <exclusion>
           <groupId>stax</groupId>

--- a/cxplugin-server/pom.xml
+++ b/cxplugin-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cxplugin</artifactId>
         <groupId>com.checkmarx.teamcity</groupId>
-        <version>2021.3.1</version>
+        <version>2021.4.1</version>
     </parent>
     <artifactId>cxplugin-server</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.checkmarx.teamcity</groupId>
     <artifactId>cxplugin</artifactId>
-    <version>2021.3.1</version>
+    <version>2021.4.1</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
Teamcity plugin before this was using older version of cx-client-common, which was dependent on log4j2. This was changed in recent version of cx-client-common to not use log4j2 and instead use commons-logging. 

Indirect dependencies of log4j 1.2.12 in TeamCity plugin from TeamCity agent and server SDK are only dev dependencies.  Hence, can be ignore. 

Results are reviewed and approved. 
https://sca.checkmarx.net/#/projects/1f32e738-11ab-4d91-beb8-b82e6fa96c37/reports/48f8e82c-18a7-44ec-936b-a2910e691491/vulnerabilities/all